### PR TITLE
remove encrypt import in __version__

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,5 @@ setup(
     packages=find_packages(exclude=['smime/test', 'smime/crypto/testdata',
         'smime/crypto/tools', '*_test.py']),
     platforms=["all"],
-    setup_requires=['asn1crypto', 'pycrypto'],
     install_requires=['pycrypto', 'asn1crypto'],
 )

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,6 @@ setup(
     packages=find_packages(exclude=['smime/test', 'smime/crypto/testdata',
         'smime/crypto/tools', '*_test.py']),
     platforms=["all"],
+    setup_requires=['asn1crypto', 'pycrypto'],
     install_requires=['pycrypto', 'asn1crypto'],
 )

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,5 @@ setup(
     packages=find_packages(exclude=['smime/test', 'smime/crypto/testdata',
         'smime/crypto/tools', '*_test.py']),
     platforms=["all"],
-    install_requires=['pycrypto'],
+    install_requires=['pycrypto', 'asn1crypto'],
 )

--- a/smime/__init__.py
+++ b/smime/__init__.py
@@ -4,6 +4,4 @@ __author__ = 'G. B. Versiani'
 __license__ = 'Apache License (2.0)'
 __version__ = '0.0.1'
 
-from .encrypt import encrypt
-
-__all__ = [encrypt, __author__, __license__, __version__]
+__all__ = [__author__, __license__, __version__]


### PR DESCRIPTION
I think the encrypt is not necessary in __init__.py file.
In Python 3.5 generate pip error "asn1crypto no module found" when install from github. 